### PR TITLE
Fix for restarting plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.jonathang'
-version = '1.0.3'
+version = '1.0.4'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/com/jonathang/TickFixerPlugin.java
+++ b/src/main/java/com/jonathang/TickFixerPlugin.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -17,24 +18,25 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 @PluginDescriptor(name = "Tick Fixer for Mac")
 public class TickFixerPlugin extends Plugin {
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService executor;
     private final AtomicInteger failureCount = new AtomicInteger(0);
 
     @Override
     protected void startUp() {
-        log.info("Tick Fixer v1.0.3 started"); // Remember to update build.gradle when changing version
+        log.info("Tick Fixer v1.0.4 started"); // Remember to update build.gradle when changing version
 
         if (OSType.getOSType() != OSType.MacOS) {
             log.error("Operating system is not Mac. Terminating.");
             return;
         }
 
+        createExecutor();
         startPing();
     }
 
     @Override
     protected void shutDown() {
-        executor.shutdown();
+        shutdownExecutor();
         log.info("Tick Fixer stopped");
     }
 
@@ -92,5 +94,17 @@ public class TickFixerPlugin extends Plugin {
                 log.error(e.getMessage());
             }
         }, 0, 200, TimeUnit.MILLISECONDS);
+    }
+
+    private void createExecutor() {
+        if (Objects.isNull(executor) || executor.isShutdown()) {
+            executor = Executors.newSingleThreadScheduledExecutor();
+        }
+    }
+
+    private void shutdownExecutor() {
+        if (Objects.nonNull(executor)) {
+            executor.shutdown();
+        }
     }
 }


### PR DESCRIPTION
The plugin fails to start properly if it has been shut down once. It requires fully exiting RuneLite to start again.
Logs:
```
(redacted_time+0) [AWT-EventQueue-0] INFO  com.jonathang.TickFixerPlugin - Tick Fixer v1.0.3 started
(redacted_time+1) [AWT-EventQueue-0] INFO  com.jonathang.TickFixerPlugin - Tick Fixer stopped
(redacted_time+2) [AWT-EventQueue-0] INFO  com.jonathang.TickFixerPlugin - Tick Fixer v1.0.3 started
(redacted_time+3) [AWT-EventQueue-0] WARN  n.r.c.plugins.config.PluginListPanel - Error when starting plugin TickFixerPlugin
net.runelite.client.plugins.PluginInstantiationException: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@567a6052[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@60ecec9[Wrapped task = com.jonathang.TickFixerPlugin$$Lambda$2604/0x00000008008a8458@641600df]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@21b26154[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1223]
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@567a6052[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@60ecec9[Wrapped task = com.jonathang.TickFixerPlugin$$Lambda$2604/0x00000008008a8458@641600df]] rejected from java.util.concurrent.ScheduledThreadPoolExecutor@21b26154[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 1223]
	at com.jonathang.TickFixerPlugin.startPing(TickFixerPlugin.java:67)
	at com.jonathang.TickFixerPlugin.startUp(TickFixerPlugin.java:32)
```

According to [the docs](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html), thread pools cannot execute new tasks after shutdown has been called:
> New tasks submitted in method [execute(Runnable)](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html#execute-java.lang.Runnable-) will be rejected when the Executor has been shut down

This change creates a new threadpool every start. I also increased the version.

Note that I am not sure how to load a third party plugin for testing, but it does build. Testing would be appreciated! I'll try to figure it out in the next few days if needed.